### PR TITLE
Implementing test procedure for CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+        with: 
+          submodules: true
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: ['hydra']
 jobs:
-  build_hydra:
+  build:
     runs-on: ubuntu-20.04
     steps:
       -

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: ['hydra']
 jobs:
-  build_coins:
+  build_hydra:
     runs-on: ubuntu-20.04
     steps:
       -

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: true
       -
         name: Build and execute tests
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+          depth: 0
       -
         name: Build and execute tests
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,8 +8,17 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
-        name: Build
-        run: docker build -t hydra:latest .
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build and push latest
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          tags: hydra:latest
       -
         name: Execute tests
         run: docker run --entrypoint=make hydra:latest check

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,22 +3,20 @@ on: push
 jobs:
   build_and_test:
     runs-on: ubuntu-20.04
+    container:
+      image: gostartups/ubuntu-leveldb4.8:latest
     steps:
       -
         name: Checkout
         uses: actions/checkout@v2
       -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Build and push latest
-        uses: docker/build-push-action@v2
-        with:
-          push: false
-          tags: hydra:latest
-      -
-        name: Execute tests
-        run: docker run --entrypoint=make hydra:latest check
+        name: Build and execute tests
+        run: |
+          ./autogen.sh
+          ./configure --without-gui BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
+          make
+          make checks
+
+
+
+        

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,4 +19,4 @@ jobs:
           ./autogen.sh
           ./configure --without-gui BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
           make
-          make checks
+          make check

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,7 +1,7 @@
 name: Create and publish the coin's containers
 on: push
 jobs:
-  build_coins:
+  build_and_test:
     runs-on: ubuntu-20.04
     steps:
       -

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,6 +15,7 @@ jobs:
       -
         name: Build and execute tests
         run: |
+          git submodule update --init --recursive
           ./autogen.sh
           ./configure --without-gui BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
           make

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-          depth: 0
+          fetch-dept: 0
       -
         name: Build and execute tests
         run: |
@@ -19,7 +19,3 @@ jobs:
           ./configure --without-gui BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
           make
           make checks
-
-
-
-        

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,11 +8,8 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        name: Build
+        run: docker build -t hydra:latest .
       -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Build and run tests
-        run: docker build -t hydra:latest . && docker run --entrypoint=make hydra:latest check
+        name: Execute tests
+        run: docker run --entrypoint=make hydra:latest check

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-          fetch-dept: 0
       -
         name: Build and execute tests
         run: |


### PR DESCRIPTION
## As the repository had no CI for executing the `make check` I decided that it would be good idea to implement that. The PR features:
- Build script for hydra based on gostartups/ubuntu-leveldb4.8 docker image
- GitHub Actions script to perform the build and check